### PR TITLE
music: send a link as a reply to bypass Music category check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 /config.ini
 /config.py
 /tgbot.session
+/tgbot.session-journal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A Telegram bot made with [Pyrogram Smart Plugins](https://docs.pyrogram.org/topi
 ## Run
 
 1. `virtualenv venv` to create a virtual environment
-2. install `libwebp-devel`, clear cache of pip (`~/.cache/pip` on linux distro)
+2. install `python3-devel zlib-devel libjpeg-turbo-devel libwebp-devel`,
+   clear cache of pip (`~/.cache/pip` on linux distro)
    for building wheel for Pillow.
    `venv/bin/pip install -U -r requirements.txt` to install the requirements
 3. Create a new `config.ini` file, copy-paste the following and replace the

--- a/plugins/music.py
+++ b/plugins/music.py
@@ -1,6 +1,8 @@
 """Download music from YouTube/SoundCloud/Mixcloud, convert thumbnail
 to square thumbnail and upload to Telegram
 
+Send a link as a reply to bypass Music category check
+
 # requirements.txt
 OpenCC
 Pillow
@@ -83,7 +85,9 @@ async def _fetch_and_send_music(message: Message):
         }
         ydl = YoutubeDL(ydl_opts)
         info_dict = ydl.extract_info(message.text, download=False)
-        if _youtube_video_not_music(info_dict):
+        # send a link as a reply to bypass Music category check
+        if not message.reply_to_message \
+                and _youtube_video_not_music(info_dict):
             inform = ("This won't be downloaded "
                       "because it's not under Music category")
             await _reply_and_delete_later(message, inform,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 OpenCC
 Pillow
-Pyrogram==1.0.7
+Pyrogram
 TgCrypto
 youtube-dl


### PR DESCRIPTION
Switch to latest version of Pyrogram (1.1.8) since corruption uploads issue (-404) is fixed

when you share a music which is not under music category, you can just send the link again but as a reply (to the previous message maybe), and it will not check if it's under music category.

It's not perfect, but it works and it's the most simple way I can think of to deal with this.

Allow to use a separate `/audio [link]` command to download audio or reply to previous message with `/audio` sounds better but the implementation will be much dirty.

We can also check custom entity, but it's not clean and easy to use as this one.